### PR TITLE
basic installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-.idea
 __pycache__/
-utils/_pycache__/
+*.egg-info/
+build/
+dist/
 
+.python-version
 
+.idea

--- a/examples/ndm/ndm_demo.py
+++ b/examples/ndm/ndm_demo.py
@@ -1,17 +1,19 @@
 """A demo for detecting novelty with a model learned from given data.
 
 """
-# Authors: kun.bj@outlook.com
-#
-# License: xxx
-import os
+import pathlib
 
 from sklearn.model_selection import train_test_split
 
 from ndm.model import MODEL
 from utils.tool import dump_data, load_data
 
+
 RANDOM_STATE = 42
+
+EXAMPLES_PATH = pathlib.Path(__file__).parent.parent
+
+DATA_FILE = EXAMPLES_PATH / 'out' / 'data' / 'demo_IAT.dat'
 
 
 def generate_model(model_name='GMM'):
@@ -56,9 +58,8 @@ def generate_model(model_name='GMM'):
     return model
 
 
-def main():
+def main(data_file=DATA_FILE):
     # load data
-    data_file = 'out/data/demo_IAT.dat'
     X, y = load_data(data_file)
     # split train and test test
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=RANDOM_STATE)
@@ -80,8 +81,8 @@ def main():
     ndm.test(X_test, y_test)
 
     # dump data to disk
-    out_dir = os.path.dirname(data_file)
-    dump_data((model, ndm.history), out_file=f'{out_dir}/{ndm.model_name}-results.dat')
+    out_file = data_file.parent / f'{ndm.model_name}-results.dat'
+    dump_data((model, ndm.history), out_file=out_file)
 
     print(ndm.train.tot_time, ndm.test.tot_time, ndm.score)
 

--- a/examples/pparser/pparser_demo.py
+++ b/examples/pparser/pparser_demo.py
@@ -1,27 +1,36 @@
 """A demo for parsing pcap and labelling the extracted flows.
 
 """
-# Authors: kun.bj@outlook.com
-#
-# License: xxx
-import os
+import pathlib
 
 from pparser.parser import PCAP
 from utils.tool import dump_data
 
+
 RANDOM_STATE = 42
 
+EXAMPLES_PATH = pathlib.Path(__file__).parent.parent
 
-def main():
-    pcap_file = 'data/demo.pcap'
-    pp = PCAP(pcap_file, flow_ptks_thres=2, verbose=10, random_state=RANDOM_STATE)
+OUT_PATH = EXAMPLES_PATH / 'out'
+
+PCAP_FILE = EXAMPLES_PATH / 'data' / 'demo.pcap'
+
+LABEL_FILE = EXAMPLES_PATH / 'data'/ 'demo.csv'
+
+
+def main(pcap_file=PCAP_FILE, label_file=LABEL_FILE):
+    pp = PCAP(
+        str(pcap_file),    # scapy doesn't appear to support Path
+        flow_ptks_thres=2,
+        verbose=10,
+        random_state=RANDOM_STATE,
+    )
 
     # extract flows from pcap
     pp.pcap2flows(q_interval=0.9)
 
     # label each flow with a label
-    label_file = 'data/demo.csv'
-    pp.label_flows(label_file=label_file)
+    pp.label_flows(label_file=str(label_file))
 
     # extract features from each flow given feat_type
     # feat_type in ['IAT', 'SIZE', 'STATS', 'SAMP_NUM', 'SAMP_SIZE']
@@ -31,8 +40,11 @@ def main():
 
     # dump data to disk
     X, y = pp.features, pp.labels
-    out_dir = os.path.join('out', os.path.dirname(pcap_file))
-    dump_data((X, y), out_file=f'{out_dir}/demo_{feat_type}.dat')
+    out_dir =  pathlib.Path(pcap_file).parent
+    if not out_dir.is_absolute():
+        out_dir = OUT_PATH / out_dir.name
+    out_file = out_dir / f'demo_{feat_type}.dat'
+    dump_data((X, y), out_file=out_file)
 
     print(pp.features.shape, pp.pcap2flows.tot_time, pp.flow2features.tot_time)
 

--- a/readme.md
+++ b/readme.md
@@ -1,117 +1,131 @@
-### A python library, "Outlier Detection (odet)",  is created for network novelty detection, which mainly includes two submodules: pcap parpser ('pparser') and novelty detection models ('ndm'). 'pparser' is for parsing pcaps to flow features by [Scapy](https://scapy.net/) , while 'ndm' is for detecting novelties by different models, such as OCSVM.
+# odet
 
-# Architecture:
-    - docs/: 
-        includes all documents (such as APIs)
-    - examples/: 
-        includes toy examples and datasets for you to play with it 
-    - ndm/: 
-        includes different detection models (such as OCSVM)
-    - pparser/: 
-        includes pcap propcess (feature extraction from pcap) 
-    - scripts/: 
-        others (such as xxx.sh, make) 
-    - tests/: 
-        includes test cases
-    - utils/: 
-        includes common functions (such as load data and dump data)
-    - visul/: 
-        includes visualization functions
-    - LICENSE.txt
-    - readme.md
-    - requirements.txt
-    - setup.py
-    - version.txt
-   
+"Outlier Detection" (odet) is a Python library for network anomaly detection.
+
+`odet` contains two primary submodules:
+
+* pcap parser: `pparser`\
+`pparser` is for parsing pcaps to flow features, using [Scapy](https://scapy.net/).
+
+* novelty detection modeling: `ndm`\
+`ndm` is for detecting novelty / anomaly, via different models, such as OCSVM.
+
     
-# How to install?
-```
-    python3 setup.py build
-    python3 setup.py install
-```
+## Installation
+
+From a repository clone:
+
+    pip install .
 
 
-# How to use?
-- PCAP to features
+## Use
+
+### PCAP to features
+
 ```python3
-    import os
+import os
 
-    from pparser.parser import PCAP
-    from utils import dump_data
-    
-    RANDOM_STATE = 42
-    
-    pcap_file = 'data/demo.pcap'
-    pp = PCAP(pcap_file, flow_ptks_thres=2, verbose=10, random_state=RANDOM_STATE)
+from pparser.parser import PCAP
+from utils import dump_data
 
-    # extract flows from pcap
-    pp.pcap2flows(q_interval=0.9)
+RANDOM_STATE = 42
 
-    # label each flow with a label
-    label_file = 'data/demo.csv'
-    pp.label_flows(label_file=label_file)
+pcap_file = 'data/demo.pcap'
+pp = PCAP(pcap_file, flow_ptks_thres=2, verbose=10, random_state=RANDOM_STATE)
 
-    # extract features from each flow given feat_type
-    feat_type = 'IAT'
-    pp.flow2features(feat_type, fft=False, header=False)
+# extract flows from pcap
+pp.pcap2flows(q_interval=0.9)
 
-    # dump data to disk
-    X, y = pp.features, pp.labels
-    out_dir = os.path.join('out', os.path.dirname(pcap_file))
-    dump_data((X, y), out_file=f'{out_dir}/demo_{feat_type}.dat')
+# label each flow with a label
+label_file = 'data/demo.csv'
+pp.label_flows(label_file=label_file)
 
-    print(pp.features.shape, pp.pcap2flows.tot_time, pp.flow2features.tot_time)
+# extract features from each flow given feat_type
+feat_type = 'IAT'
+pp.flow2features(feat_type, fft=False, header=False)
 
+# dump data to disk
+X, y = pp.features, pp.labels
+out_dir = os.path.join('out', os.path.dirname(pcap_file))
+dump_data((X, y), out_file=f'{out_dir}/demo_{feat_type}.dat')
+
+print(pp.features.shape, pp.pcap2flows.tot_time, pp.flow2features.tot_time)
 ```
 
-- Novelty detection
+### Novelty detection
+
 ```python3
-    import os
+import os
 
-    from sklearn.model_selection import train_test_split
-    
-    from ndm.model import MODEL
-    from ndm.ocsvm import OCSVM
-    from utils.tool import dump_data, load_data
-    
-    RANDOM_STATE = 42
+from sklearn.model_selection import train_test_split
 
-    # load data
-    data_file = 'out/data/demo_IAT.dat'
-    X, y = load_data(data_file)
-    # split train and test test
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=RANDOM_STATE)
+from ndm.model import MODEL
+from ndm.ocsvm import OCSVM
+from utils.tool import dump_data, load_data
 
-    # create detection model
-    model = OCSVM(kernel='rbf', nu=0.5, random_state=RANDOM_STATE)
-    model.name = 'OCSVM'
-    ndm = MODEL(model, score_metric='auc', verbose=10, random_state=RANDOM_STATE)
+RANDOM_STATE = 42
 
-    # learned the model from the train set
-    ndm.train(X_train, y_train)
+# load data
+data_file = 'out/data/demo_IAT.dat'
+X, y = load_data(data_file)
+# split train and test test
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=RANDOM_STATE)
 
-    # evaluate the learned model
-    ndm.test(X_test, y_test)
+# create detection model
+model = OCSVM(kernel='rbf', nu=0.5, random_state=RANDOM_STATE)
+model.name = 'OCSVM'
+ndm = MODEL(model, score_metric='auc', verbose=10, random_state=RANDOM_STATE)
 
-    # dump data to disk
-    out_dir = os.path.dirname(data_file)
-    dump_data((model, ndm.history), out_file=f'{out_dir}/{ndm.model_name}-results.dat')
+# learned the model from the train set
+ndm.train(X_train, y_train)
 
-    print(ndm.train.tot_time, ndm.test.tot_time, ndm.score)
+# evaluate the learned model
+ndm.test(X_test, y_test)
+
+# dump data to disk
+out_dir = os.path.dirname(data_file)
+dump_data((model, ndm.history), out_file=f'{out_dir}/{ndm.model_name}-results.dat')
+
+print(ndm.train.tot_time, ndm.test.tot_time, ndm.score)
 ```
 
-- For more examples, please check the 'examples' directory 
-    
+For more examples, please check the 'examples' directory.
 
 
-# TODO
+## Architecture
+
+- docs/: 
+    includes all documents (such as APIs)
+- examples/: 
+    includes toy examples and datasets for you to play with it 
+- ndm/: 
+    includes different detection models (such as OCSVM)
+- pparser/: 
+    includes pcap propcess (feature extraction from pcap) 
+- scripts/: 
+    others (such as xxx.sh, make) 
+- tests/: 
+    includes test cases
+- utils/: 
+    includes common functions (such as load data and dump data)
+- visul/: 
+    includes visualization functions
+- LICENSE.txt
+- readme.md
+- requirements.txt
+- setup.py
+- version.txt
+
+
+## To Do
+
 The current version just implements basic functions. We still need to further evaluate and optimize them continually. 
+
 - Evaluate 'pparser' performance on different pcaps
 - Add setup.py for 'install'
 - Add 'test' cases
 - Add license
 - Add more examples
 - Generated docs from docs-string automatically
-
 
 Welcome to make any comments to make it more robust and easier to use!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-numpy==1.18.3
-scipy==1.4.1
-pandas==0.25.1
-scapy==2.4.3
-scikit-learn==0.21.3
-matplotlib==3.2.1
-pytest==5.3.1
-requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -1,66 +1,58 @@
-"""Setup.py
-    python3 setup.py build
-    python3 setup.py install
+"""setup.py
+
+Due to scikit-learn, pip is required:
+
+    pip install .
+
 """
-# Authors: kun.bj@outlook.com
-#
-# License: xxx
-import os
+import pathlib
 
 from setuptools import find_packages
 from setuptools import setup
 
 
-def read(readme_file):
-    """Utility function to read the README file. Used for the long_description.
+README_PATH = pathlib.Path(__file__).parent / 'readme.md'
 
-    Parameters
-    ----------
-    readme_file: str
+INSTALL_REQUIRES = (
+    'numpy==1.18.3',
+    'pandas==0.25.1',
+    'scapy==2.4.3',
+    'scikit-learn==0.23.1',
+)
 
-    Returns
-    -------
-
-    """
-
-    value = open(os.path.join(os.path.dirname(__file__), readme_file), 'r', encoding='utf-8').read()
-    return str(value)
+EXTRAS_REQUIRE = {
+    # (as yet) unused:
+    # 'visualize': ['matplotlib==3.2.1'],
+    # 'tests': ['pytest==5.3.1', 'requests==2.22.0'],
+}
 
 
 setup(name='odet',
       version='0.0.1',
       description='Novelty Detection',
-      long_description=read('readme.md'),
-      # long_description='Data representation for IoT traffic',
+      long_description=README_PATH.read_text(),
       long_description_content_type="text/markdown",
       author='Kun',
       author_email='kun.bj@outlook.com',
       url='https://github.com/Learn-Live/odet',
       download_url='https://github.com/Learn-Live/odet',
       license='xxx',
-      python_requires='==3.7.3',
-      install_requires=['numpy==1.18.3',
-                        'scipy==1.4.1',
-                        'pandas==0.25.1',
-                        'scapy==2.4.3',
-                        'scikit-learn==0.21.3'
-                        ],
-      extras_require={
-          'visualize': ['matplotlib==3.2.1'],
-          'tests': ['pytest==5.3.1',
-                    'requests==2.22.0'
-                    ],
-      },
+      python_requires='>=3.7.3,<4',
+      install_requires=INSTALL_REQUIRES,
+      extras_require=EXTRAS_REQUIRE,
       classifiers=[
-          'Development Status :: 5 - Production/Stable',
+          'Development Status :: 2 - Pre-Alpha',
           'Intended Audience :: Developers',
           'Intended Audience :: Education',
           'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: Python Software Foundation License',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
           'Topic :: Software Development :: Libraries',
           'Topic :: Software Development :: Libraries :: Python Modules'
+          'Topic :: Scientific/Engineering :: Artificial Intelligence',
+          'Topic :: System :: Networking :: Monitoring',
       ],
       # automatically find the packages with __init__.py file and start from the setup.py's directory
-      packages=find_packages())
+      packages=find_packages(),
+)


### PR DESCRIPTION
### Summary

In reviewing the library, I found that it was unclear how to build/install it, and the documented installation instructions did not work. (Certainly I may have been missing something!)

Regardless, I corrected the installation instructions and cleaned up the build/install module (`setup.py`) and the `readme.md`.

### Installation

* installation of this library was unclear:
  * both setup.py and requirements.txt provided, and unconnected to each
other (latter removed)
  * unused/unnecessary requirements (commented-out/removed respectively)

* instruction to build & install appears incorrect:
  * generally unnecessary to `setup.py build` & `setup.py install`; the
latter command does both
  * these instructions insufficient, due to scikit-learn – setuptools
alone *cannot* install this dependency in this manner, and so this
procedure fails. (rather this dependency, and therefore the entire
library, must be installed via `pip` – as it would be installed from
PyPI.)

* python version requirement loosened (no need to require a micro
version -- rather, should aim to support the remainder of the major
version 3)

* library likely can't yet be considered "production/stable" (rather,
pre-alpha)

* software license as yet undetermined (but likely not Python
Foundation's own)

### Documentation

* readme.md cleaned up for clarity of language and formatting, and to
correct installation instructions.

### Examples

* for now, simply made examples executable from any working directory, (rather than only from the `examples/` subdirectory)

---

FYI – and thanks to – @Learn-Live 