### PR TITLE
(Assuming #16 is merged) Remove unnecessary 0s from features

### DIFF
--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -801,16 +801,16 @@ class PCAP:
         else:
             msg = f'feat_type ({feat_type}) is not correct! '
             raise ValueError(msg)
-        dim = self.dim
+
         if fft:
-            self.features = _get_FFT_data(self.features, fft_bin=dim)
+            self.features = _get_FFT_data(self.features, fft_bin=self.dim)
         else:
             # fix each flow to the same feature dimension (cut off the flow or append 0 to it)
-            self.features = [v[:dim] if len(v) > dim else v + [0] * (dim - len(v)) for v in self.features]
+            self.features = [v[:self.dim] if len(v) > self.dim else v + [0] * (self.dim - len(v)) for v in self.features]
 
         if header:
             _headers = _get_header_features(self.flows)
-            h_dim = 8 + dim  # 8 TCP flags
+            h_dim = 8 + self.dim  # 8 TCP flags
             if fft:
                 fft_headers = _get_FFT_data(_headers, fft_bin=h_dim)
                 self.features = [h + f for h, f in zip(fft_headers, self.features)]

--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -785,7 +785,7 @@ class PCAP:
             self.dim = 2 * dim - 1
             self.features, self.fids = _get_IAT_SIZE(self.flows)
         elif feat_type in ['STATS']:
-            self.dim = 10
+            self.dim = 12
             self.features, self.fids = _get_STATS(self.flows)
         elif feat_type in ['SAMP_NUM', 'FFT-SAMP_NUM']:
             self.dim = dim - 1
@@ -801,7 +801,7 @@ class PCAP:
         else:
             msg = f'feat_type ({feat_type}) is not correct! '
             raise ValueError(msg)
-
+        dim = self.dim
         if fft:
             self.features = _get_FFT_data(self.features, fft_bin=dim)
         else:


### PR DESCRIPTION
As of now, we truncate/append 0s so that all rows are of length `dim`. However, we don't update `dim`, but rather `self.dim`, depending on the type of features. This PR makes it so that we do truncation according to the correct value of `dim`, ensuring that extraneous 0s are not added.