### PR TITLE
Warn about `random_state` usage across NDM classes

### DIFF
--- a/src/netml/ndm/ae.py
+++ b/src/netml/ndm/ae.py
@@ -109,9 +109,7 @@ class AE(BaseDetector):
         verbose: int (default is 1)
             A print level is to control what information should be printed according to the given value.
             The higher the value is, the more info is printed.
-
-        random_state: int (default is 42)
-
+        
         """
         self.epochs = epochs
         self.batch_size = batch_size

--- a/src/netml/ndm/ae.py
+++ b/src/netml/ndm/ae.py
@@ -71,7 +71,7 @@ class AE(BaseDetector):
                  loss='mse',
                  dropout_rate=0.2,
                  l2_regularizer=0.1, validation_size=0.1,
-                 verbose=1, random_state=42, contamination=0.1, hid_dim=16, lat_dim=8):
+                 verbose=1, contamination=0.1, hid_dim=16, lat_dim=8, **kwargs):
         """AutoEncoder
 
         Parameters
@@ -120,13 +120,17 @@ class AE(BaseDetector):
         self.l2_regularizer = l2_regularizer
         self.validation_size = validation_size
         self.verbose = verbose
-        self.random_state = random_state
         self.lr = lr
         self.contamination = contamination
         self.hid_dim = hid_dim
         self.lat_dim = lat_dim
 
         check_parameter(dropout_rate, 0, 1, param_name='dropout_rate', include_left=True)
+
+        if "random_state" in kwargs and verbose > 5:
+            print(
+                "Warning: 'random_state' passed to AutoEncoder. Use torch.manual_seed() instead."
+            )
 
         if self.loss == 'mse' or (not self.loss):
             self.criterion = nn.MSELoss()

--- a/src/netml/ndm/gmm.py
+++ b/src/netml/ndm/gmm.py
@@ -71,6 +71,8 @@ class GMM(GaussianMixture, BaseDetector):
         contamination: float (default is 0.1)
              It's in range (0,1). A threshold used to decide the normal score (not used).
 
+        random_state: int (default is 42)
+
         """
         self.n_components = n_components
         self.covariance_type = covariance_type

--- a/src/netml/ndm/kde.py
+++ b/src/netml/ndm/kde.py
@@ -16,7 +16,7 @@ class KDE(KernelDensity, BaseDetector):
 
     def __init__(self, bandwidth=1.0, algorithm='auto',
                  kernel='gaussian', metric="euclidean", atol=0, rtol=0, contamination=0.1,
-                 breadth_first=True, leaf_size=40, metric_params=None, random_state=42):
+                 breadth_first=True, leaf_size=40, metric_params=None, verbose=0, **kwargs):
         """Kernel density estimation (KDE)
         Parameters
         ----------
@@ -63,7 +63,11 @@ class KDE(KernelDensity, BaseDetector):
         self.leaf_size = leaf_size
         self.metric_params = metric_params
         self.contamination = contamination
-        self.random_state = random_state
+
+        if "random_state" in kwargs and verbose > 5:
+            print(
+                "Warning: 'random_state' passed to KDE has no effect."
+            )
 
         # run the choose algorithm code so that exceptions will happen here
         # we're using clone() in the GenerativeBayes classifier,

--- a/src/netml/ndm/kde.py
+++ b/src/netml/ndm/kde.py
@@ -66,7 +66,7 @@ class KDE(KernelDensity, BaseDetector):
 
         if "random_state" in kwargs and verbose > 5:
             print(
-                "Warning: 'random_state' passed to KDE has no effect."
+                "Warning: argument 'random_state' passed to KDE has no effect."
             )
 
         # run the choose algorithm code so that exceptions will happen here

--- a/src/netml/ndm/model.py
+++ b/src/netml/ndm/model.py
@@ -28,9 +28,6 @@ class MODEL:
             a print level is to control what information should be printed according to the given value.
             The higher the value is, the more info is printed.
 
-        random_state: int
-            a value is to make your experiments more reproducible.
-
         Returns
         -------
             a MODEL instance
@@ -47,8 +44,6 @@ class MODEL:
             self.random_state = kwargs["random_state"]
             if verbose > 5:
                 print("Warning: setting random_state for a model wrapper doesn't affect the underlying predictions.")
-        else:
-            self.random_state = 42
 
     @timing
     def _train(self, X_train, y_train=None):

--- a/src/netml/ndm/model.py
+++ b/src/netml/ndm/model.py
@@ -13,7 +13,7 @@ from netml.utils.tool import timing
 
 class MODEL:
 
-    def __init__(self, model=None, *, score_metric='auc', verbose=1, random_state=42):
+    def __init__(self, model=None, *, score_metric='auc', verbose=1, **kwargs):
         """Train and test a model on a given data.
 
         Parameters
@@ -40,9 +40,15 @@ class MODEL:
         self.model_name = model.name
         self.score_metric = score_metric
         self.verbose = verbose
-        self.random_state = random_state
         # store all data generated during training and testing the model.
         self.history = {}
+
+        if "random_state" in kwargs:
+            self.random_state = kwargs["random_state"]
+            if verbose > 5:
+                print("Warning: setting random_state for a model wrapper doesn't affect the underlying predictions.")
+        else:
+            self.random_state = 42
 
     @timing
     def _train(self, X_train, y_train=None):

--- a/src/netml/ndm/ocsvm.py
+++ b/src/netml/ndm/ocsvm.py
@@ -12,7 +12,7 @@ class OCSVM(OneClassSVM):
 
     def __init__(self, kernel='rbf', degree=3, gamma='scale',
                  coef0=0.0, tol=1e-3, nu=0.5, shrinking=True, cache_size=200,
-                 verbose=False, max_iter=-1, random_state=100):
+                 verbose=False, max_iter=-1, **kwargs):
         """One Class SVM (OCSVM)
 
         Parameters
@@ -49,10 +49,13 @@ class OCSVM(OneClassSVM):
 
         verbose: bool (default is False)
             Enable verbose output.
-
-        random_state: int (default is 42)
-
         """
+
+        if "random_state" in kwargs and verbose > 5:
+            print(
+                "Warning: 'random_state' passed to OCSVM has no effect."
+            )
+
         super(OCSVM, self).__init__(
             kernel=kernel,
             degree=degree,
@@ -66,7 +69,6 @@ class OCSVM(OneClassSVM):
             max_iter=max_iter,
         )
 
-        self.random_state = random_state
         self.verbose = verbose
 
     # override decision_function. because test and grid_search will use decision_function first

--- a/src/netml/ndm/ocsvm.py
+++ b/src/netml/ndm/ocsvm.py
@@ -53,7 +53,7 @@ class OCSVM(OneClassSVM):
 
         if "random_state" in kwargs and verbose > 5:
             print(
-                "Warning: 'random_state' passed to OCSVM has no effect."
+                "Warning: argument 'random_state' passed to OCSVM has no effect."
             )
 
         super(OCSVM, self).__init__(

--- a/src/netml/ndm/pca.py
+++ b/src/netml/ndm/pca.py
@@ -14,7 +14,7 @@ class PCA(BaseDetector):
 
     def __init__(self, n_components=None, n_selected_components=None,
                  contamination=0.1, copy=True, whiten=False, svd_solver='auto',
-                 tol=0.0, iterated_power='auto', random_state=None,
+                 tol=0.0, iterated_power='auto', random_state=42,
                  weighted=True, standardization=True):
         """Principal component analysis (PCA)
 
@@ -48,7 +48,7 @@ class PCA(BaseDetector):
             Number of iterations for the power method computed by
             svd_solver == 'randomized'.
 
-        random_state : int
+        random_state: int (default is 42)
 
         weighted : bool, optional (default=True)
             If True, the eigenvalues are used in score computation.

--- a/src/netml/ndm/pca.py
+++ b/src/netml/ndm/pca.py
@@ -15,7 +15,7 @@ class PCA(BaseDetector):
     def __init__(self, n_components=None, n_selected_components=None,
                  contamination=0.1, copy=True, whiten=False, svd_solver='auto',
                  tol=0.0, iterated_power='auto', random_state=42,
-                 weighted=True, standardization=True):
+                 weighted=True, standardization=True, verbose=1):
         """Principal component analysis (PCA)
 
         Parameters
@@ -70,6 +70,7 @@ class PCA(BaseDetector):
         self.weighted = weighted
         self.standardization = standardization
         self.score_name = "reconstructed"  # the way to obtain outlier scores
+        self.verbose = verbose
 
         self.contamination = contamination
 

--- a/src/netml/ndm/pca.py
+++ b/src/netml/ndm/pca.py
@@ -15,7 +15,7 @@ class PCA(BaseDetector):
     def __init__(self, n_components=None, n_selected_components=None,
                  contamination=0.1, copy=True, whiten=False, svd_solver='auto',
                  tol=0.0, iterated_power='auto', random_state=42,
-                 weighted=True, standardization=True, verbose=1):
+                 weighted=True, standardization=True, verbose=0):
         """Principal component analysis (PCA)
 
         Parameters


### PR DESCRIPTION
Many NDM models expose a `random_state` parameter, but its behavior varies because different models rely on different underlying libraries (`scikit-learn`, `PyOD`, `PyTorch`). As a result, some models produce deterministic output while others ignore the argument entirely. This is also confusing when users pass a model instance to create a `MODEL` object, which has its own `random_state` parameter with no effect.

Changes included:
 * Added warnings (shown when `verbose  > 5`) when random_state is passed but the relevant class doesn't use the parameter.
 * Preserved backward compatibility by continuing to accept random_state via kwargs.
 * Removed `random_state` from signatures where it is nonfunctional.

I also made some arbitrary decisions to try and match the current repository:
 * I chose `verbose > 5` as the threshold, mimicking the AutoEncoder threshold for debug output; however, other parts of the repo use different cutoffs
 * I added `verbose` to PCA's function signature with a default value of 0. Other initializers default to `verbose=False` or `verbose=1`.

Hopefully these updates make reproducibility expectations clearer without breaking anyone's existing projects.